### PR TITLE
Fixed kextdevmode check

### DIFF
--- a/Continuity Activation Tool.app/Contents/MacOS/contitool.sh
+++ b/Continuity Activation Tool.app/Contents/MacOS/contitool.sh
@@ -273,7 +273,7 @@ function isMyBluetoothCompatible(){
 #Verifies if the kext developer mode is active. If not, it is activated (reboot required).
 function disableOsKextProtection(){
 	echo -n "Verifying OS kext protection...         "
-	sudo nvram boot-args | grep -F "kext-dev-mode=1"
+	sudo nvram boot-args | grep -F "kext-dev-mode=1" > /dev/null
 	kextDevMode=$?
 	if [ $kextDevMode -eq 0 ]; then
 		if [ "$1" != "verbose" ]; then echo "OK";


### PR DESCRIPTION
The previous version would not correctly detect the kextdevmode=1 in case there were other bootflags, like -v.
Now it uses the exit status of grep (using string match) to understand whether "kextdevmode=1" is present or not.
