### PR TITLE
Fixed sw_vers call for compatibility with case-sensitive filesystems.

### DIFF
--- a/Continuity Activation Tool.app/Contents/Resources/contitool.sh
+++ b/Continuity Activation Tool.app/Contents/Resources/contitool.sh
@@ -133,7 +133,7 @@ function verifyStringsUtilPresence() {
 function isMyMacOSCompatible() {	
 	echo -n "Verifying OS X version...               "
 	local osVersion=$(sw_vers -productVersion)
-	local buildVersion=$(sw_Vers -buildVersion)
+	local buildVersion=$(sw_vers -buildVersion)
 	local minVersion=10
 	local subVersion=$(echo "$osVersion" | $cutPath -d '.' -f 2)
 	


### PR DESCRIPTION
I've changed sw_Vers to sw_vers - with case-sensitive filesystems the first one won't work.