### PR TITLE
Fix bluetooth version check on OS X 10.11

### DIFF
--- a/Continuity Activation Tool.app/Contents/Resources/contitool.sh
+++ b/Continuity Activation Tool.app/Contents/Resources/contitool.sh
@@ -342,7 +342,7 @@ function isMyMacModelCompatible(){
 function isMyBluetoothVersionCompatible(){
 	echo -n "Verifying Bluetooth version...          "
 
-	local lmpVersion=$($ioregPath -l | $grepPath "LMPVersion" | $awkPath -F' = ' '{print $2}')
+	local lmpVersion=$($ioregPath -l | $grepPath "LMPVersion" | $awkPath -F' = ' '{print $2}' | $headPath -n 1)
 
 	if [ ! "${lmpVersion}" == "" ]; then
 		if [ "${lmpVersion}" == "6" ]; then


### PR DESCRIPTION
This pull request fixes a situation that happens on OS X 10.11 when checking LMP version.

On OS X 10.11 the commands

    lmpVersion=$(ioreg -l | grep "LMPVersion" | awk -F' = ' '{print $2}')

returns two numbers:

    6
    6

 which isn't well interpreted by the comparison

     if [ "${lmpVersion}" == "6" ]

By changing the line to 

    lmpVersion=$(ioreg -l | grep "LMPVersion" | awk -F' = ' '{print $2}' | head -n 1)

we use only the first number, thus making comparison work again.